### PR TITLE
[Fix] client로 enum type value를 전달하도록 수정

### DIFF
--- a/src/main/java/com/hana4/sonjumoney/dto/response/MemberResponse.java
+++ b/src/main/java/com/hana4/sonjumoney/dto/response/MemberResponse.java
@@ -1,7 +1,6 @@
 package com.hana4.sonjumoney.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.hana4.sonjumoney.domain.enums.MemberRole;
 
 import lombok.Builder;
 
@@ -14,13 +13,13 @@ public record MemberResponse(
 	@JsonProperty("member_name")
 	String memberName,
 	@JsonProperty("member_role")
-	MemberRole memberRole
+	String memberRole
 ) {
 	public static MemberResponse of(
 		Long memberId,
 		Long userId,
 		String memberName,
-		MemberRole memberRole
+		String memberRole
 	) {
 		return MemberResponse.builder()
 			.memberId(memberId)

--- a/src/main/java/com/hana4/sonjumoney/service/FamilyService.java
+++ b/src/main/java/com/hana4/sonjumoney/service/FamilyService.java
@@ -42,7 +42,7 @@ public class FamilyService {
 			for (Member fbfMember : findByFamilyIdMembers) {
 				memberResponses.add(
 					MemberResponse.of(fbfMember.getId(), fbfMember.getUser().getId(), fbfMember.getUser().getUsername(),
-						fbfMember.getMemberRole()));
+						fbfMember.getMemberRole().getValue()));
 			}
 			GetFamilyResponse getFamilyResponse = GetFamilyResponse.of(family.getId(), family.getFamilyName(),
 				memberResponses);


### PR DESCRIPTION
## ⭐ Related Issue

- close #86 
  <br/>

## 📃 Feature Description

- 기존 client로 enum type을 보내던 (ex. MemberRole의 Son) 코드를 enum type의 value를 보내도록 수정했습니다. (ex. MemberRole의 Son -> "아들")
  <br/>

## 💡 Plan

- 다음 계획 간단히
