### PR TITLE
[Fix] 대리인 주민등록번호 추가

### DIFF
--- a/src/main/java/com/hana4/sonjumoney/service/AccountService.java
+++ b/src/main/java/com/hana4/sonjumoney/service/AccountService.java
@@ -122,6 +122,7 @@ public class AccountService {
 			.user(user)
 			.bank(Bank.HANA)
 			.holderResidentNum(user.getResidentNum())
+			.deputyResidentNum(mockAccount.getDeputyResidentNum())
 			.accountNum(mockAccount.getAccountNum())
 			.accountPassword(mockAccount.getAccountPassword())
 			.balance(mockAccount.getBalance())


### PR DESCRIPTION
계좌 추가할 때 대리인 주민등록번호가 not null인데 빠져있어서 추가했습니다.